### PR TITLE
Fix errors and typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 composer.phar
 /vendor/
 .php_cs.cache
+tests/fixtures/assets/*

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -85,7 +85,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_var_annotation_correct_order' => true,
         'phpdoc_var_without_name' => true,
         'return_type_declaration' => true,
-        'semicolon_after_instruction' => true,
+        'semicolon_after_instruction' => false,
         'short_scalar_cast' => true,
         'simplified_null_return' => true,
         'single_blank_line_before_namespace' => true,

--- a/README.md
+++ b/README.md
@@ -3,13 +3,20 @@ A php parser to create stylesheet files just in time
 
 
 ## How to use
-```
-StyleJit\StyleJit::$path = "assets"; // set the path to save the stylesheets
-StyleJit\StyleJit::$refresh = true;  // comment this on production
+```php
+<?php
 
-...
-$cssFile = StyleJit\StyleJit::fileName();
-echo '<link href="assets/' . $cssFile . '" type="stylesheet">';
+use StyleJit\StyleJit;
+
+include_once 'vendor/autoload.php'; // autoload resources from composer
+
+$_SERVER['REQUEST_URI'] = 'fixtures/example.php';
+
+StyleJit::$path = __DIR__.'/assets'; // set the path to save the stylesheets
+StyleJit::$refresh = true;  // comment this on production
+
+// ...
+echo '<link href="assets/' . StyleJit::fileName() . '" type="stylesheet">';
 ```
 
 ## Run the tests

--- a/src/StyleJit.php
+++ b/src/StyleJit.php
@@ -36,7 +36,7 @@ class StyleJit
 
     public static function fileName(): string
     {
-        $fileName = $_SERVER['REQUEST_URI'].'.css';
+        $fileName = md5($_SERVER['REQUEST_URI']).'.css';
 
         if (self::$refresh === false) {
             return $fileName;
@@ -44,9 +44,10 @@ class StyleJit
 
         // render the stylesheet on exit of the script
         register_shutdown_function(static function () use ($fileName) {
-            $output = ob_get_contents();
+            $output = ob_get_clean();
             $style = self::renderStyle($output);
             file_put_contents(self::$path.'/'.$fileName, $style);
+            echo $output;
         });
 
         return $fileName;

--- a/src/StyleJit.php
+++ b/src/StyleJit.php
@@ -27,9 +27,9 @@ class StyleJit
         }
 
         // render the stylesheet on exit of the script
-        register_shutdown_function(function () {
+        register_shutdown_function(static function () use ($fileName) {
             $output = ob_get_contents();
-            $style = renderStyle($output);
+            $style = self::renderStyle($output);
             file_put_contents(self::$path.'/'.$fileName, $style);
         });
 
@@ -90,13 +90,13 @@ class StyleJit
         }
 
         $attribute = self::findBestAttribute($attribute);
-        $value = self::readAttrubuteValue($value);
+        $value = self::readAttributeValue($value);
 
         $classValue = $attribute.':'.$value;
 
         $definition = '.'.strtr($name, [':' => '\\:']).$pseudo.'{'.$classValue.'}';
         if ($media !== '') {
-            // TODO seperate media clausures to reduce output size
+            // TODO separate media closures to reduce output size
             $definition = '@media '.(self::$mediaMap[$media] ?? $media).$definition.'}';
         }
 
@@ -128,22 +128,23 @@ class StyleJit
                 return $property;
             }
             preg_match('/'.$regex.'/', $property, $output_array);
-            if (!empty($output_array) && $attr[0] === $property[0]) {
-                if (substr_count($attr, '-') === substr_count($property, '-')) {
-                    return $property;
-                }
+            if (
+                !empty($output_array) && $attr[0] === $property[0] &&
+                substr_count($attr, '-') === substr_count($property, '-')
+            ) {
+                return $property;
             }
         }
 
         return $attr;
     }
 
-    public static function readAttrubuteValue(string $value): string
+    public static function readAttributeValue(string $value): string
     {
         // add the spaces and commas in attributes
         $value = strtr($value, ['_' => ' ', '\\,' => ',']);
 
-        if ($value[0] === '-') {
+        if (strpos($value, '-') === 0) {
             $value = 'var('.$value.')';
         }
 

--- a/tests/StyleJitTest.php
+++ b/tests/StyleJitTest.php
@@ -12,6 +12,11 @@ use StyleJit\StyleJit;
  */
 class StyleJitTest extends TestCase
 {
+    public function testFileName(): void
+    {
+
+    }
+
     public function testRenderStyle(): void
     {
         // double and single quotes
@@ -35,7 +40,7 @@ class StyleJitTest extends TestCase
         $this->assertEquals('.p-l\\:1em{padding-left:1em}', $css);
 
         // value attributes
-        $css = StyleJit::renderStyle('<div class="dis:grid gr-t-c:1fr_1fr">Save</a>');
+        $css = StyleJit::renderStyle('<div class="dis:grid gr-t-c:1fr_1fr">Save</div>');
         $this->assertEquals('.dis\\:grid{display:grid}.gr-t-c\\:1fr_1fr{grid-template-columns:1fr 1fr}', $css);
     }
 }

--- a/tests/StyleJitTest.php
+++ b/tests/StyleJitTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 include_once __DIR__.'/../vendor/autoload.php';
 include_once __DIR__.'/../src/StyleJit.php';
 use PHPUnit\Framework\TestCase;
@@ -10,7 +12,7 @@ use StyleJit\StyleJit;
  */
 class StyleJitTest extends TestCase
 {
-    public function testRenderStyle()
+    public function testRenderStyle(): void
     {
         // double and single quotes
         $css = StyleJit::renderStyle('<a class="padding:1em">Save</a>');

--- a/tests/StyleJitTest.php
+++ b/tests/StyleJitTest.php
@@ -16,14 +16,17 @@ class StyleJitTest extends TestCase
     {
         $css = StyleJit::renderStyle('<a class="padding:1em">Save</a>');
         $this->assertEquals('.padding\\:1em{padding:1em}', $css);
+
         $css = StyleJit::renderStyle('<a class="pad:1em">Save</a>');
         $this->assertEquals('.pad\\:1em{padding:1em}', $css);
+
         $css = StyleJit::renderStyle('<a class="p-lft:1em">Save</a>');
         $this->assertEquals('.p-lft\\:1em{padding-left:1em}', $css);
+
         $css = StyleJit::renderStyle('<a class="p-l:1em">Save</a>');
         $this->assertEquals('.p-l\\:1em{padding-left:1em}', $css);
 
-        $css = StyleJit::renderStyle('<div class="dis:grid gr-t-c:1fr_1fr">Save</a>');
+        $css = StyleJit::renderStyle('<div class="dis:grid gr-t-c:1fr_1fr">Save</div>');
         $this->assertEquals('.dis\\:grid{display:grid}.gr-t-c\\:1fr_1fr{grid-template-columns:1fr 1fr}', $css);
     }
 }

--- a/tests/StyleJitTest.php
+++ b/tests/StyleJitTest.php
@@ -3,20 +3,33 @@
 declare(strict_types=1);
 
 include_once __DIR__.'/../vendor/autoload.php';
-include_once __DIR__.'/../src/StyleJit.php';
 use PHPUnit\Framework\TestCase;
 use StyleJit\StyleJit;
 
 /**
- * @covers \StyleJit\StyleJit
+ * @coversDefaultClass  \StyleJit\StyleJit
  */
 class StyleJitTest extends TestCase
 {
+    /**
+     * @covers ::fileName
+     */
     public function testFileName(): void
     {
+        ob_start();
+        passthru('php tests/fixtures/exampleTemplate.php', $exitCode);
+        $output = ob_get_clean();
 
+        $this->assertEquals(0, $exitCode);
+
+        preg_match('/<link href="(.*\.css)" type="stylesheet">/sim', $output, $matches);
+
+        $this->assertFileExists($matches[1]);
     }
 
+    /**
+     * @covers ::renderStyle
+     */
     public function testRenderStyle(): void
     {
         // double and single quotes

--- a/tests/StyleJitTest.php
+++ b/tests/StyleJitTest.php
@@ -16,10 +16,13 @@ class StyleJitTest extends TestCase
     {
         $css = StyleJit::renderStyle('<a class="padding:1em">Save</a>');
         $this->assertEquals('.padding\\:1em{padding:1em}', $css);
+
         $css = StyleJit::renderStyle('<a class="pad:1em">Save</a>');
         $this->assertEquals('.pad\\:1em{padding:1em}', $css);
+
         $css = StyleJit::renderStyle('<a class="p-lft:1em">Save</a>');
         $this->assertEquals('.p-lft\\:1em{padding-left:1em}', $css);
+
         $css = StyleJit::renderStyle('<a class="p-l:1em">Save</a>');
         $this->assertEquals('.p-l\\:1em{padding-left:1em}', $css);
 

--- a/tests/StyleJitTest.php
+++ b/tests/StyleJitTest.php
@@ -10,31 +10,30 @@ use StyleJit\StyleJit;
  */
 class StyleJitTest extends TestCase
 {
-	public function testRenderStyle()
-	{
-    // double and single quotes
-    $css = StyleJit::renderStyle('<a class="padding:1em">Save</a>');
-    $this->assertEquals('.padding\\:1em{padding:1em}', $css);
+    public function testRenderStyle()
+    {
+        // double and single quotes
+        $css = StyleJit::renderStyle('<a class="padding:1em">Save</a>');
+        $this->assertEquals('.padding\\:1em{padding:1em}', $css);
 
-    $css = StyleJit::renderStyle('<a class="padding:1em">Save</a>');
-    $this->assertEquals('', $css); // existing class
+        $css = StyleJit::renderStyle('<a class="padding:1em">Save</a>');
+        $this->assertEquals('', $css); // existing class
 
-    $css = StyleJit::renderStyle("<a class='margin:1em'>Save</a>");
-    $this->assertEquals('.margin\\:1em{margin:1em}', $css);
+        $css = StyleJit::renderStyle("<a class='margin:1em'>Save</a>");
+        $this->assertEquals('.margin\\:1em{margin:1em}', $css);
 
-    // abbreviations
-    $css = StyleJit::renderStyle('<a class="pad:1em">Save</a>');
-    $this->assertEquals('.pad\\:1em{padding:1em}', $css);
+        // abbreviations
+        $css = StyleJit::renderStyle('<a class="pad:1em">Save</a>');
+        $this->assertEquals('.pad\\:1em{padding:1em}', $css);
 
-    $css = StyleJit::renderStyle('<a class="p-lft:1em">Save</a>');
-    $this->assertEquals('.p-lft\\:1em{padding-left:1em}', $css);
+        $css = StyleJit::renderStyle('<a class="p-lft:1em">Save</a>');
+        $this->assertEquals('.p-lft\\:1em{padding-left:1em}', $css);
 
-    $css = StyleJit::renderStyle('<a class="p-l:1em">Save</a>');
-    $this->assertEquals('.p-l\\:1em{padding-left:1em}', $css);
+        $css = StyleJit::renderStyle('<a class="p-l:1em">Save</a>');
+        $this->assertEquals('.p-l\\:1em{padding-left:1em}', $css);
 
-    // value attributes
-    $css = StyleJit::renderStyle('<div class="dis:grid gr-t-c:1fr_1fr">Save</a>');
-    $this->assertEquals('.dis\\:grid{display:grid}.gr-t-c\\:1fr_1fr{grid-template-columns:1fr 1fr}', $css);
-  }
-
+        // value attributes
+        $css = StyleJit::renderStyle('<div class="dis:grid gr-t-c:1fr_1fr">Save</a>');
+        $this->assertEquals('.dis\\:grid{display:grid}.gr-t-c\\:1fr_1fr{grid-template-columns:1fr 1fr}', $css);
+    }
 }

--- a/tests/fixtures/exampleTemplate.php
+++ b/tests/fixtures/exampleTemplate.php
@@ -1,0 +1,27 @@
+<?php
+
+use StyleJit\StyleJit;
+
+include_once __DIR__.'/../../vendor/autoload.php';
+
+$_SERVER['REQUEST_URI'] = 'fixtures/example.php';
+
+StyleJit::$path = __DIR__.'/assets'; // set the path to save the stylesheets
+StyleJit::$refresh = true;  // comment this on production
+
+ob_start();
+?>
+<html lang="en">
+    <head>
+        <title>Example HTML for testing StyleJit</title>
+        <link href="<?php echo StyleJit::$path.'/'.StyleJit::fileName(); ?>" type="stylesheet">
+    </head>
+    <body>
+        <div><a class="padding:1em">Save</a></div>
+        <div><a class='margin:1em'>Save</a></div>
+        <div><a class="pad:1em">Save</a></div>
+        <div><a class="p-lft:1em">Save</a></div>
+        <div><a class="p-l:1em">Save</a></div>
+        <div class="dis:grid gr-t-c:1fr_1fr">Save</div>
+    </body>
+</html>

--- a/tests/fixtures/exampleTemplate.php
+++ b/tests/fixtures/exampleTemplate.php
@@ -14,7 +14,7 @@ ob_start();
 <html lang="en">
     <head>
         <title>Example HTML for testing StyleJit</title>
-        <link href="<?php echo StyleJit::$path.'/'.StyleJit::fileName(); ?>" type="stylesheet">
+        <link href="<?= StyleJit::$path.'/'.StyleJit::fileName() ?>" type="stylesheet">
     </head>
     <body>
         <div><a class="padding:1em">Save</a></div>


### PR DESCRIPTION
Closes #15 



### Added

- Add directory `assets`.
- Add exclusion of `tests/fixtures/assets/*` in `.gitignore`.
- Add `tests/fixtures/exampleTemplate.php` Fixture.
- Add specific coverage of the Test methods.
- Add strict types to StyleJitTest.
- Add Test for `StyleJit\StyleJit::fileName`.

### Changed

- Method `StyleJit\StyleJit::fileName` hashes the `$_SERVER['REQUEST_URI']`
  with md5 in order to avoid potential filesystem problems.
  The shutdown function registered echoes output buffer output.

### Fixed

- Fix README.md "How to use" section, with working example.
- Fix `StyleJitTest::testRenderStyle` value attributes.
- Fix CS after solving conflicts.
